### PR TITLE
Fix missing fmt argument in error message

### DIFF
--- a/src/query/abbrev.rs
+++ b/src/query/abbrev.rs
@@ -50,7 +50,7 @@ impl FromStr for AbbrevUrl {
 
         let captures = regex
             .captures(s)
-            .ok_or_else(|| anyhow!("path: {} does not match Abbrev url regex"))?;
+            .ok_or_else(|| anyhow!("path: {} does not match Abbrev url regex", s))?;
 
         let username = captures.get(1).map(|s| s.as_str().to_owned()).unwrap();
         let path = captures.get(2).map(|s| s.as_str().to_owned()).unwrap();

--- a/src/query/inner.rs
+++ b/src/query/inner.rs
@@ -36,6 +36,6 @@ impl FromStr for Query {
         } else if let Ok(abbrev) = AbbrevUrl::parse(s) {
             return Ok(Query::Abbrev(abbrev));
         }
-        Err(anyhow!("'{}' invalid query not url or scp path"))
+        Err(anyhow!("'{}' invalid query not url or scp path", s))
     }
 }


### PR DESCRIPTION
Without this, the error messages would literally be "path: {} does not match Abbrev url regex" and "'{}' invalid query not url or scp path", with curly braces in them instead of the input string.